### PR TITLE
Key integrity enforcement for get implementation 

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -12,6 +12,9 @@ module Dalli
   # socket/server communication error
   class NetworkError < DalliError; end
 
+  # socket returned unexpected value error
+  class SocketCorruptionError < NetworkError; end
+
   # no server available/alive error
   class RingError < DalliError; end
 

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -53,7 +53,7 @@ module Dalli
       @normalized_servers = ::Dalli::ServersArgNormalizer.normalize_servers(servers)
       @options = normalize_options(options)
 
-      if @options[:safe_get].present? && @options[:safe_get] == true && @options[:protocol].present? && @options[:protocol] != :binary
+      if @options[:safe_get] == true && !@options[:protocol].nil? && @options[:protocol] != :binary
         raise NotImplementedError, "Safe get is not implemented for the #{@options[:protocol]} protocol"
       end
 

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -61,7 +61,7 @@ module Dalli
     # Get the value associated with the key.
     # If a value is not found, then +nil+ is returned.
     def get(key, req_options = nil)
-      perform(:get, key, req_options)
+      perform(:getk, key, req_options)
     end
 
     ##

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -54,7 +54,7 @@ module Dalli
       @options = normalize_options(options)
 
       if @options[:safe_get].present? && @options[:safe_get] == true && @options[:protocol].present? && @options[:protocol] != :binary
-        raise NotImplementedError, "Safe get is not implemented for the #{@options[:protocol]} protocol}"
+        raise NotImplementedError, "Safe get is not implemented for the #{@options[:protocol]} protocol"
       end
 
       @key_manager = ::Dalli::KeyManager.new(@options)

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -45,16 +45,13 @@ module Dalli
     #                   useful for injecting a FIPS compliant hash object.
     # - :protocol - one of either :binary or :meta, defaulting to :binary.  This sets the protocol that Dalli uses
     #               to communicate with memcached.
-    # - :safe_get - if true Dalli will use getk to get key with value and check that the keys match. This protects against 
-    #               socket corruption at the cost of additional overhead to retrieve and compare keys. 
-    #               This is currently only implemented for the binary protocol. Default: false
     #
     def initialize(servers = nil, options = {})
       @normalized_servers = ::Dalli::ServersArgNormalizer.normalize_servers(servers)
       @options = normalize_options(options)
 
-      if @options[:safe_get] == true && !@options[:protocol].nil? && @options[:protocol] != :binary
-        raise NotImplementedError, "Safe get is not implemented for the #{@options[:protocol]} protocol"
+      if !@options[:protocol].nil? && @options[:protocol] != :binary
+        raise NotImplementedError, "This fork does not support the #{@options[:protocol]} protocol because safe_get is not implemented"
       end
 
       @key_manager = ::Dalli::KeyManager.new(@options)
@@ -68,12 +65,8 @@ module Dalli
     ##
     # Get the value associated with the key.
     # If a value is not found, then +nil+ is returned.
-    def get(key, req_options = nil)
-      if @options[:safe_get] != true
-        perform(:get, key, req_options)
-      else 
-        perform(:safe_get, key, req_options)
-      end
+    def get(key, req_options = nil)   
+      perform(:safe_get, key, req_options)
     end
 
     ##

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -18,7 +18,7 @@ module Dalli
 
       def_delegators :@value_marshaller, :serializer, :compressor, :compression_min_size, :compress_by_default?
       def_delegators :@connection_manager, :name, :sock, :hostname, :port, :close, :connected?, :socket_timeout,
-                     :socket_type, :up!, :down!, :write, :reconnect_down_server?, :raise_down_error
+                     :socket_type, :up!, :down!, :write, :reconnect_down_server?, :raise_down_error, :error_on_request!
 
       def initialize(attribs, client_options = {})
         hostname, port, socket_type, @weight, user_creds = ServerConfigParser.parse(attribs)

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -28,7 +28,7 @@ module Dalli
       def safe_get(key, options = nil)
         req = RequestFormatter.standard_request(opkey: :getk, key: key)
         write(req)
-        response_processor.getk(cache_nils: cache_nils?(options), key: key)&.last
+        response_processor.getk(key, cache_nils: cache_nils?(options)).last
       rescue Dalli::SocketCorruptionError => e
         Dalli.logger.debug { e.inspect }
         

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -25,6 +25,12 @@ module Dalli
         response_processor.get(cache_nils: cache_nils?(options))
       end
 
+      def getk(key, options = nil)
+        req = RequestFormatter.standard_request(opkey: :getk, key: key)
+        write(req)
+        response_processor.getk(cache_nils: cache_nils?(options), key: key)&.last
+      end
+
       def quiet_get_request(key)
         RequestFormatter.standard_request(opkey: :getkq, key: key)
       end

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -17,7 +17,7 @@ module Dalli
       end
 
       private
-      
+
       # Retrieval Commands
       def safe_get(key, options = nil)
         req = RequestFormatter.standard_request(opkey: :getk, key: key)

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -23,11 +23,7 @@ module Dalli
         write(req)
         response_processor.getk(key, cache_nils: cache_nils?(options)).last
       rescue Dalli::SocketCorruptionError => e
-        Dalli.logger.debug { e.inspect }
-        
-        # Close connection; connection manager logic will automatically reopen it after a delay.
-        # This raises its own network error handled upstream.
-        down!   
+        error_on_request!(e)
       end
 
       def quiet_get_request(key)

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -17,7 +17,8 @@ module Dalli
       end
 
       private
-
+      
+      # Retrieval Commands
       def safe_get(key, options = nil)
         req = RequestFormatter.standard_request(opkey: :getk, key: key)
         write(req)

--- a/lib/dalli/protocol/binary.rb
+++ b/lib/dalli/protocol/binary.rb
@@ -18,13 +18,6 @@ module Dalli
 
       private
 
-      # Retrieval Commands
-      def get(key, options = nil)
-        req = RequestFormatter.standard_request(opkey: :get, key: key)
-        write(req)
-        response_processor.get(cache_nils: cache_nils?(options))
-      end
-
       def safe_get(key, options = nil)
         req = RequestFormatter.standard_request(opkey: :getk, key: key)
         write(req)

--- a/lib/dalli/protocol/binary/request_formatter.rb
+++ b/lib/dalli/protocol/binary/request_formatter.rb
@@ -21,6 +21,7 @@ module Dalli
           flush: 0x08,
           noop: 0x0A,
           version: 0x0B,
+          getk: 0x0c,
           getkq: 0x0D,
           append: 0x0E,
           prepend: 0x0F,
@@ -52,6 +53,7 @@ module Dalli
 
         BODY_FORMATS = {
           get: KEY_ONLY,
+          getk: KEY_ONLY,
           getkq: KEY_ONLY,
           delete: KEY_ONLY,
           deleteq: KEY_ONLY,

--- a/lib/dalli/protocol/binary/response_processor.rb
+++ b/lib/dalli/protocol/binary/response_processor.rb
@@ -66,7 +66,7 @@ module Dalli
           raise Dalli::DalliError, "Response error #{resp_header.status}: #{RESPONSE_CODES[resp_header.status]}"
         end
 
-        def get(cache_nils: false)
+        def getk(cache_nils: false, key: nil)
           resp_header, body = read_response
 
           return false if resp_header.not_stored? # Not stored, normal status for add operation
@@ -75,7 +75,19 @@ module Dalli
           raise_on_not_ok!(resp_header)
           return true unless body
 
-          unpack_response_body(resp_header, body, true).last
+          res = unpack_response_body(resp_header, body, true)
+
+          if key.present?
+            if key != res.first
+              raise Dalli::NetworkError, "Socket corruption detected - key does not match response"
+            end
+          end
+
+          res
+        end
+
+        def get(cache_nils: false)
+          getk(cache_nils: cache_nils).last
         end
 
         ##

--- a/lib/dalli/protocol/binary/response_processor.rb
+++ b/lib/dalli/protocol/binary/response_processor.rb
@@ -66,7 +66,7 @@ module Dalli
           raise Dalli::DalliError, "Response error #{resp_header.status}: #{RESPONSE_CODES[resp_header.status]}"
         end
 
-        def getk(cache_nils: false, key: nil)
+        def get(cache_nils: false)
           resp_header, body = read_response
 
           return false if resp_header.not_stored? # Not stored, normal status for add operation
@@ -75,19 +75,28 @@ module Dalli
           raise_on_not_ok!(resp_header)
           return true unless body
 
+          unpack_response_body(resp_header, body, true).last
+        end
+
+        # returns [key, value]
+        def getk(cache_nils: false, key: nil)
+          resp_header, body = read_response
+
+          return false if resp_header.not_stored? # Not stored, normal status for add operation
+          return cache_nils ? ::Dalli::NOT_FOUND : [key, nil] if resp_header.not_found?
+
+          raise_on_not_ok!(resp_header)
+          return true unless body
+
           res = unpack_response_body(resp_header, body, true)
 
           if key.present?
             if key != res.first
-              raise Dalli::NetworkError, "Socket corruption detected - key does not match response"
+              raise Dalli::SocketCorruptionError, "Socket corruption detected - key does not match response"
             end
           end
 
           res
-        end
-
-        def get(cache_nils: false)
-          getk(cache_nils: cache_nils).last
         end
 
         ##

--- a/lib/dalli/protocol/binary/response_processor.rb
+++ b/lib/dalli/protocol/binary/response_processor.rb
@@ -79,7 +79,9 @@ module Dalli
         end
 
         # returns [key, value]
-        def getk(cache_nils: false, key: nil)
+        # raises SocketCorruptionError if the response key does not match the requested key. 
+        # otherwise mirrors the get implementation 
+        def getk(key, cache_nils: false)
           resp_header, body = read_response
 
           return false if resp_header.not_stored? # Not stored, normal status for add operation
@@ -90,10 +92,8 @@ module Dalli
 
           res = unpack_response_body(resp_header, body, true)
 
-          if key.present?
-            if key != res.first
-              raise Dalli::SocketCorruptionError, "Socket corruption detected - key does not match response"
-            end
+          if key != res.first
+            raise Dalli::SocketCorruptionError, "Socket corruption detected - key does not match response"
           end
 
           res


### PR DESCRIPTION
Dalli will issue getk (get key and value) instead of get ops to memcached, and ensure that the returned key matches the requested key. This guarantees that even in the case of socket corruption or otherwise, we cannot return incorrect values for requested keys. The connection is reset if keys do not match, retrying and recovering gracefully. The return format and client interface are unchanged. 

Using getk vs get comes at the cost of some performance overhead due to key retrieval and comparison. This performance cost would be most significant when caching a large number of small values with comparatively large keys. [Edit] After profiling this in a Rails app, there is no appreciable performance degradation. 